### PR TITLE
윈도우환경에서 lint설정 오류가 나오던점 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,12 @@
     "react/no-unused-state": "warn",
     "react/jsx-key": "warn",
     "react/self-closing-comp": "warn",
-    "react/jsx-curly-brace-presence": "warn"
+    "react/jsx-curly-brace-presence": "warn",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 기존 윈도우 환경에서 lint 설정 오류가 나오던점 수정

## 📝 참고 사항

- 유닉스 시스템(맥)에서는 한줄의 끝이 LF(Line Feed)로 처리가 되고
윈도우 시스템에서는 한줄의 끝이 CRLF(Carriage Return Line Feed)로 처리가 된다

## 🖼️ 스크린샷


## 🚨 관련 이슈

-
-

## ✅ 이후 계획

-
-
