### PR TITLE
Input component 생성

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -1,0 +1,12 @@
+import * as S from './InputStyle';
+
+const Input = ({ children }) => {
+  return (
+    <S.Container>
+      <S.Input placeholder={children} />
+      <S.ErrorMessage>내용을 입력해주세요.</S.ErrorMessage>
+    </S.Container>
+  );
+};
+
+export default Input;

--- a/src/components/Input/InputStyle.js
+++ b/src/components/Input/InputStyle.js
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 20rem;
+`;
+
+export const Input = styled.input`
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: var(--white);
+  border: 0.0625rem solid var(--gray-300);
+  color: var(--gray-500);
+  font-family: Pretendard;
+  font-size: 1rem;
+  line-height: 1.625rem;
+  letter-spacing: -0.01rem;
+
+  &:focus {
+    border: 0.125rem solid var(--gray-500);
+    color: var(--gray-900);
+  }
+
+  &:active {
+    border: 0.125rem solid var(--gray-700);
+    color: var(--gray-900);
+  }
+
+  &:hover {
+    border: 0.0625rem solid var(--gray-500);
+  }
+
+  &:disabled {
+    background: var(--gray-100);
+    color: var(--gray-400);
+  }
+
+  &.errorMessage {
+    border: 0.0625rem solid var(--error);
+    color: var(--gray-900);
+  }
+`;
+
+export const ErrorMessage = styled.p`
+  display: none;
+  color: var(--error);
+  font-family: Pretendard;
+  font-size: var(--font-12);
+  line-height: 1.125rem;
+  letter-spacing: -0.0037rem;
+
+  &.errorMessage {
+    display: block;
+  }
+`;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] Input component 생성

## 📝 참고 사항

- 사용되는 페이지에 따라 placeholder가 달라, `children`으로 placeholder 메세지를 출력하도록 구현하였습니다. 사용 시 참고해주세요.
- input 내 placeholder 및 value의 경우, 기본 font-size가 16px로 적용되지 않아서, font-size를 `1 rem`으로 지정해두었습니다.
- error 스타일의 경우, className으로 `errorMessage`를 가질 때 적용되도록 구현하였습니다.

## 🖼️ 스크린샷

- inactive
![inactive](https://github.com/CreativePaperCrew/RollingPaper/assets/79499733/4c5cfff2-8d32-4b22-a8d2-2c155180afd8)

- hover
![hover](https://github.com/CreativePaperCrew/RollingPaper/assets/79499733/c57a23b9-e999-482e-9ea7-927210b851cb)

- active 
![image](https://github.com/CreativePaperCrew/RollingPaper/assets/79499733/a61f75e8-4a5a-48d3-aa87-6deb8ba651a9)

- error
![image](https://github.com/CreativePaperCrew/RollingPaper/assets/79499733/ea051271-2613-4f21-82b3-4c8dcb6ed12b)



## 🚨 관련 이슈

-

## ✅ 이후 계획

- `/post` 페이지와 `/post/{id}/message` 페이지에서 Input component 사용 예정입니다.