### PR TITLE
롤링페이퍼 및 카드에대한 폰트 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,12 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nanum+Myeongjo&family=Nanum+Pen+Script&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
     <title>RollingPaper</title>
   </head>
   <body>

--- a/src/FontStyle.js
+++ b/src/FontStyle.js
@@ -1,0 +1,19 @@
+import { css } from 'styled-components';
+
+const fontFamilies = {
+  'Noto Sans': css`
+    font-family: 'Noto Sans', sans-serif;
+  `,
+  Pretendard: css`
+    font-family: 'Pretendard', sans-serif;
+  `,
+  나눔명조: css`
+    font-family: 'Nanum Myeongjo', serif;
+  `,
+  '나눔손글씨 손편지체': css`
+    font-family: 'Nanum Pen Script', cursive;
+  `,
+};
+
+export const getfontStyle = (fontName) =>
+  fontFamilies[fontName] || fontFamilies.Pretendard;

--- a/src/components/CardModal/CardModal.jsx
+++ b/src/components/CardModal/CardModal.jsx
@@ -26,7 +26,7 @@ const CardModal = ({ cardData, onClose }) => {
           </S.CardProfile>
         </S.CardTop>
         <S.ContentContainer>
-          <S.Content>{content}</S.Content>
+          <S.Content $font={font}>{content}</S.Content>
         </S.ContentContainer>
         <S.ModalCloseButton onClick={onClose}>확인</S.ModalCloseButton>
       </S.ModalContent>

--- a/src/components/CardModal/CardModalStyle.js
+++ b/src/components/CardModal/CardModalStyle.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { getfontStyle } from '../../FontStyle';
 import { Button } from '../BackgroundTypeSelectButton/BackgroundTypeSelectButtonStyle';
 
 export const ModalBackground = styled.div`
@@ -140,6 +141,7 @@ export const Content = styled.p`
   padding-right: 0.5rem;
   color: var(--gray-600);
   font-size: var(--font-15);
+  ${(props) => getfontStyle(props.$font)}
   line-height: 1.5rem;
   overflow: auto;
 

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -28,7 +28,7 @@ const PostCard = ({ cardData, onClick }) => {
         </S.PostCardProfile>
       </S.PostCardTop>
       <S.ContentContainer>
-        <S.Content>{content}</S.Content>
+        <S.Content $font={font}>{content}</S.Content>
       </S.ContentContainer>
       <S.PostCardDate>{formatKSTDate(createdAt)}</S.PostCardDate>
     </S.PostCardContainer>

--- a/src/components/PostCard/PostCardStyle.js
+++ b/src/components/PostCard/PostCardStyle.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { getfontStyle } from '../../FontStyle';
 
 export const PostCardContainer = styled.div`
   position: relative;
@@ -112,6 +113,7 @@ export const Content = styled.p`
   width: 100%;
   color: var(--gray-600, #4a4a4a);
   font-size: var(--font-15);
+  ${(props) => getfontStyle(props.$font)}
   line-height: 1.5rem;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 카드(롤링페이퍼)에서 주요 내용부분에 대한 폰트를 적용

## 📝 참고 사항

- 
-

## 🖼️ 스크린샷

<img width="1561" alt="스크린샷 2024-03-06 오후 1 36 02" src="https://github.com/CreativePaperCrew/RollingPaper/assets/100824183/f10593c2-cb78-49f5-83d2-66e75f88adcb">


## 🚨 관련 이슈

- 

## ✅ 이후 계획

- refetch 도입
-
