### PR TITLE
버튼 컴포넌트 폰트 사이즈가 없을 시 기본값 설정

### DIFF
--- a/src/components/common/Buttons/Button/ButtonStyle.js
+++ b/src/components/common/Buttons/Button/ButtonStyle.js
@@ -37,11 +37,16 @@ export const Button = styled.button`
   text-align: center;
   cursor: pointer;
 
-  padding: ${(props) => BUTTON_SIZE[props.size].padding};
-  border-radius: ${(props) => BUTTON_SIZE[props.size].borderRadius};
-  font-size: ${(props) => BUTTON_SIZE[props.size].fontSize};
-  font-weight: ${(props) => BUTTON_SIZE[props.size].fontWeight};
-  letter-spacing: ${(props) => BUTTON_SIZE[props.size].letterSpacing};
+  padding: ${(props) =>
+    props.size ? BUTTON_SIZE[props.size].padding : '0.875rem 1.5rem'};
+  border-radius: ${(props) =>
+    props.size ? BUTTON_SIZE[props.size].borderRadius : '0.75rem'};
+  font-size: ${(props) =>
+    props.size ? BUTTON_SIZE[props.size].fontSize : 'var(--font-18'};
+  font-weight: ${(props) =>
+    props.size ? BUTTON_SIZE[props.size].fontWeight : 'var(--font-bold)'};
+  letter-spacing: ${(props) =>
+    props.size ? BUTTON_SIZE[props.size].letterSpacing : '-0.0112rem'};
   width: ${(props) => (props.size ? BUTTON_SIZE[props.size].width : '100%')};
 
   &:hover {

--- a/src/components/common/Buttons/Button/ButtonStyle.js
+++ b/src/components/common/Buttons/Button/ButtonStyle.js
@@ -42,7 +42,7 @@ export const Button = styled.button`
   border-radius: ${(props) =>
     props.size ? BUTTON_SIZE[props.size].borderRadius : '0.75rem'};
   font-size: ${(props) =>
-    props.size ? BUTTON_SIZE[props.size].fontSize : 'var(--font-18'};
+    props.size ? BUTTON_SIZE[props.size].fontSize : 'var(--font-18)'};
   font-weight: ${(props) =>
     props.size ? BUTTON_SIZE[props.size].fontWeight : 'var(--font-bold)'};
   letter-spacing: ${(props) =>


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 버튼 사이즈가 small, medium, large에 해당하지 않을 시에도 속성의 기본값을 추가하였습니다. 


## 🖼️ 스크린샷

![image](https://github.com/CreativePaperCrew/RollingPaper/assets/129318957/732c2ab6-ccb2-4d25-b607-90974eb39276)

## ✅ 이후 계획

- ListPage 리팩토링 진행할 예정입니다. 
