### PR TITLE
`/post/{id}/message` skeleton UI 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "quill-delta-to-html": "^0.12.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-loading-skeleton": "^3.4.0",
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.22.1",
     "react-scripts": "5.0.1",

--- a/src/pages/PostWritingPage/PostWritingPage.jsx
+++ b/src/pages/PostWritingPage/PostWritingPage.jsx
@@ -13,6 +13,7 @@ import TextEditor from '../../components/TextEditor/TextEditor';
 const PostWritingPage = () => {
   const [senderName, setSenderName] = useState('');
   const [profileImageUrls, setProfileImageUrls] = useState([]);
+  const [imageLoading, setImageLoading] = useState({});
   const [selectedImageUrl, setSelectedImageUrl] = useState(null);
   const [contents, setContents] = useState('');
   const [selectedInfo, setSelectedInfo] = useState({
@@ -29,6 +30,10 @@ const PostWritingPage = () => {
 
   const handleImageClick = (url) => {
     setSelectedImageUrl(url);
+  };
+
+  const handleImageLoading = (url) => {
+    setImageLoading((prev) => ({ ...prev, [url]: false }));
   };
 
   const handleOptionClick = (type, option) => {
@@ -68,6 +73,9 @@ const PostWritingPage = () => {
       .then((res) => {
         setProfileImageUrls(res.imageUrls);
         setSelectedImageUrl(res.imageUrls[0]);
+        res.imageUrls.forEach((url) => {
+          setImageLoading((prev) => ({ ...prev, [url]: true }));
+        });
       })
       .catch((error) => alert(error.message));
   }, []);
@@ -91,11 +99,16 @@ const PostWritingPage = () => {
               <S.ProfileMessage>프로필 이미지를 선택해주세요</S.ProfileMessage>
               <S.ImageList>
                 {profileImageUrls?.map((url) => (
-                  <S.AvaliableImages
-                    src={url}
-                    key={url}
-                    onClick={() => handleImageClick(url)}
-                  />
+                  <div>
+                    <S.AvailableImage
+                      src={url}
+                      key={url}
+                      onClick={() => handleImageClick(url)}
+                      onLoad={() => handleImageLoading(url)}
+                      $loading={imageLoading[url] && 'none'}
+                    />
+                    {imageLoading[url] && <S.SkeletonImage />}
+                  </div>
                 ))}
               </S.ImageList>
             </S.ImageSelector>

--- a/src/pages/PostWritingPage/PostWritingPageStyle.js
+++ b/src/pages/PostWritingPage/PostWritingPageStyle.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import { VIEWPORT_SIZE } from '../../constants/viewportSize';
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
 
 export const Container = styled.div`
   display: flex;
@@ -75,10 +77,11 @@ export const ImageList = styled.div`
   }
 `;
 
-export const AvaliableImages = styled.img`
+export const AvailableImage = styled.img`
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 70%;
+  display: ${({ $loading }) => $loading};
 
   &:hover {
     cursor: pointer;
@@ -99,4 +102,10 @@ export const MarginFrame = styled.div`
     margin-top: 12.875rem;
     margin-bottom: 1.5rem;
   }
+`;
+
+export const SkeletonImage = styled(Skeleton)`
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 70%;
 `;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] `/post/{id}/message` 프로필 이미지 부분에 skeleton UI를 추가하였습니다.

## 📝 참고 사항

- 아래 코드에서 `div` 태그와 `SkeletonImage`에 대한 key prop을 지정하지 못했습니다.

```jsx
{profileImageUrls?.map((url) => (
  <div>
    <S.AvailableImage
      src={url}
      key={url}
      onClick={() => handleImageClick(url)}
      onLoad={() => handleImageLoading(url)}
      $loading={imageLoading[url] && 'none'}
    />
    {imageLoading[url] && <S.SkeletonImage />}
  </div>
  ))}
```

## 🖼️ 스크린샷


## 🚨 관련 이슈

-

## ✅ 이후 계획

-