### PR TITLE
모달에서 글이 제대로 출력되지 않는 오류 수정

### DIFF
--- a/src/components/CardModal/CardModal.jsx
+++ b/src/components/CardModal/CardModal.jsx
@@ -1,12 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Badge from '../Badge/Badge';
 import * as S from './CardModalStyle';
 import * as PS from '../PostCard/PostCardStyle';
 import { formatKSTDate } from '../../utils/formatKSTDate';
+import InnerHtml from '../InnerHtml/InnerHtml';
 
 const CardModal = ({ cardData, onClose }) => {
+  const [isJson, setIsJson] = useState(false);
+
   const { content, createdAt, font, profileImageURL, relationship, sender } =
     cardData;
+
+  useEffect(() => {
+    try {
+      JSON.parse(content);
+      setIsJson(true);
+    } catch (error) {
+      setIsJson(false);
+    }
+  }, []);
 
   return (
     <S.ModalBackground onClick={onClose}>
@@ -27,7 +39,11 @@ const CardModal = ({ cardData, onClose }) => {
           </PS.PostCardProfile>
         </PS.PostCardTop>
         <S.ContentContainer>
-          <S.Content $font={font}>{content}</S.Content>
+          {isJson ? (
+            <InnerHtml content={content} font={font} isCard={false} />
+          ) : (
+            <S.Content $font={font}>{content}</S.Content>
+          )}
         </S.ContentContainer>
         <S.ModalCloseButton onClick={onClose} size="medium">
           확인

--- a/src/components/CardModal/CardModalStyle.js
+++ b/src/components/CardModal/CardModalStyle.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { getfontStyle } from '../../FontStyle';
 import { Button } from '../BackgroundTypeSelectButton/BackgroundTypeSelectButtonStyle';
-import InnerHtml from '../InnerHtml/InnerHtml';
 import { VIEWPORT_SIZE } from '../../constants/viewportSize';
 
 export const ModalBackground = styled.div`

--- a/src/components/CardModal/CardModalStyle.js
+++ b/src/components/CardModal/CardModalStyle.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import { getfontStyle } from '../../FontStyle';
 import { Button } from '../BackgroundTypeSelectButton/BackgroundTypeSelectButtonStyle';
+import InnerHtml from '../InnerHtml/InnerHtml';
+import { VIEWPORT_SIZE } from '../../constants/viewportSize';
 
 export const ModalBackground = styled.div`
   position: fixed;
@@ -74,6 +76,10 @@ export const ProfileImg = styled.img`
 
 export const ContentContainer = styled.div`
   height: 15rem;
+
+  @media (${VIEWPORT_SIZE.mobile}) {
+    height: 7rem;
+  }
 `;
 
 export const Content = styled.p`

--- a/src/components/InnerHtml/InnerHtml.jsx
+++ b/src/components/InnerHtml/InnerHtml.jsx
@@ -2,7 +2,7 @@ import { QuillDeltaToHtmlConverter } from 'quill-delta-to-html';
 import * as S from './InnerHtmlStyle';
 import DOMPurify from 'dompurify';
 
-const InnerHtml = ({ content, font }) => {
+const InnerHtml = ({ content, font, isCard }) => {
   const jsonData = JSON.parse(content).ops;
 
   const cfg = {
@@ -16,6 +16,7 @@ const InnerHtml = ({ content, font }) => {
   return (
     <S.HtmlContent
       $font={font}
+      $isCard={isCard}
       dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
     />
   );

--- a/src/components/InnerHtml/InnerHtmlStyle.js
+++ b/src/components/InnerHtml/InnerHtmlStyle.js
@@ -1,17 +1,47 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { getfontStyle } from '../../FontStyle';
 
-export const HtmlContent = styled.div`
+const CardHtmlContent = css`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const ModalHtmlContent = css`
+  width: 100%;
+  height: 100%;
+  margin-top: 1rem;
+  padding-right: 0.9375rem;
+  overflow: scroll;
+  overflow-x: hidden;
+
+  &::-webkit-scrollbar {
+    width: 0.3125rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--gray-300);
+    border-radius: 12px;
+  }
+  &::-webkit-scrollbar-button {
+    display: none;
+  }
+
+  @media (min-width: 768px) {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+    height: 15rem;
+  }
+`;
+
+export const HtmlContent = styled.div`
   width: 100%;
   color: var(--gray-600, #4a4a4a);
   font-size: var(--font-15);
   line-height: 1.5rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
   list-style: inside;
+  ${({ $isCard }) => ($isCard ? CardHtmlContent : ModalHtmlContent)}
 
   & * {
     ${(props) => getfontStyle(props.$font)}

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -53,7 +53,7 @@ const PostCard = ({ cardData, onClick, onDelete, isDelete }) => {
       </S.PostCardTop>
       <S.ContentContainer>
         {isJson ? (
-          <InnerHtml content={content} font={font} />
+          <InnerHtml content={content} font={font} isCard={true} />
         ) : (
           <S.Content $font={font}>{content}</S.Content>
         )}


### PR DESCRIPTION
## 🚀 작업 내용

- [x] React Quill에서 넘긴 데이터가 모달에서도 제대로 출력될 수 있도록 수정하였습니다.

## 📝 참고 사항

- 모바일에서 content가 모달 창 크기를 넘어가는 오류가 있어 반응형에 따른 높이를 조절하였습니다. (@Trophy198 )
```js
export const ContentContainer = styled.div`
  height: 15rem;

  @media (${VIEWPORT_SIZE.mobile}) {
    height: 7rem;
  }
`
```

## 🖼️ 스크린샷

![image](https://github.com/CreativePaperCrew/RollingPaper/assets/79499733/76ba3af3-0ab8-4c8a-b1f2-c25ab5821fb3)
![image](https://github.com/CreativePaperCrew/RollingPaper/assets/79499733/5b92a26a-c47c-4e6c-b9d9-392a5bf554a8)


## 🚨 관련 이슈

-

## ✅ 이후 계획

-
