### PR TITLE
Layout으로 잡힌 Header가 모든 /post페이지의 모바일 화면에서 보이지 않도록 수정

### DIFF
--- a/src/AppLayout.jsx
+++ b/src/AppLayout.jsx
@@ -1,11 +1,34 @@
-import { Outlet } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import Header from './components/common/Header/Header';
+import { VIEWPORT_SIZE } from './constants/viewportSize';
 
-const AppLayout = () => (
-  <>
-    <Header />
-    <Outlet />
-  </>
-);
+const AppLayout = () => {
+  const location = useLocation();
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia(`(${VIEWPORT_SIZE.mobile})`);
+    const handleChange = () => {
+      setIsMobile(matchMedia.matches);
+    };
+
+    handleChange();
+    matchMedia.addEventListener('change', handleChange);
+
+    return () => {
+      matchMedia.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const shouldHideHeader = location.pathname.startsWith('/post') && isMobile;
+
+  return (
+    <>
+      {!shouldHideHeader && <Header />}
+      <Outlet />
+    </>
+  );
+};
 
 export default AppLayout;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 모바일 화면에서는 헤더가 보이지 않도록 수정


## 📝 참고 사항

## 🖼️ 스크린샷

![image](https://github.com/CreativePaperCrew/RollingPaper/assets/108844881/6ca45d16-84fe-4447-8ce4-f7e59adf4cfc)

![image](https://github.com/CreativePaperCrew/RollingPaper/assets/108844881/168965f6-71ec-4224-8b01-dee0aa5a44dc)

![image](https://github.com/CreativePaperCrew/RollingPaper/assets/108844881/4acaf654-a658-4e90-b782-e50c81c67b24)


## 🚨 관련 이슈


## ✅ 이후 계획

