### PR TITLE
package-lock 버전 통합 및 react-hooks 관련 경고 비활성화

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "react/jsx-key": "warn",
     "react/self-closing-comp": "warn",
     "react/jsx-curly-brace-presence": "warn",
+    "react-hooks/exhaustive-deps": "off",
     "prettier/prettier": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "quill-delta-to-html": "^0.12.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-loading-skeleton": "^3.4.0",
         "react-quill": "^2.0.0",
         "react-router-dom": "^6.22.1",
         "react-scripts": "5.0.1",
@@ -15487,6 +15488,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.4.0.tgz",
+      "integrity": "sha512-1oJEBc9+wn7BbkQQk7YodlYEIjgeR+GrRjD+QXkVjwZN7LGIcAFHrx4NhT7UHGBxNY1+zax3c+Fo6XQM4R7CgA==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/react-quill": {
       "version": "2.0.0",

--- a/src/hooks/useFetchData.js
+++ b/src/hooks/useFetchData.js
@@ -21,8 +21,6 @@ function useFetchData(apiFunction, params = []) {
     } finally {
       setIsLoading(false);
     }
-    // params의 변화에 따라 fetchData를 재실행하기 위해 의존성 배열에 포함
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiFunction, ...params]);
 
   useEffect(() => {

--- a/src/pages/RecipientsPage/RecipientsPage.jsx
+++ b/src/pages/RecipientsPage/RecipientsPage.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 기존 react-hooks 관련 경고가 불필요하다고 판단하여 경고를 비활성화
- [x] react-loading-skeleton 라이브러리 추가로 인한 package-lock 의존성 버전 통합
- []

## 📝 참고 사항

-
-

## 🖼️ 스크린샷

![image](이미지url)

## 🚨 관련 이슈

-
-

## ✅ 이후 계획

-
-
