### PR TITLE
Toast UI 전역 context 추가

### DIFF
--- a/src/AppLayout.jsx
+++ b/src/AppLayout.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Header from './components/common/Header/Header';
 import { VIEWPORT_SIZE } from './constants/viewportSize';
+import { ToastProvider } from './contexts/ToastContext';
 
 const AppLayout = () => {
   const location = useLocation();
@@ -24,10 +25,10 @@ const AppLayout = () => {
   const shouldHideHeader = location.pathname.startsWith('/post') && isMobile;
 
   return (
-    <>
+    <ToastProvider>
       {!shouldHideHeader && <Header />}
       <Outlet />
-    </>
+    </ToastProvider>
   );
 };
 

--- a/src/components/ShareButton/ShareButton.jsx
+++ b/src/components/ShareButton/ShareButton.jsx
@@ -1,20 +1,12 @@
 import useToggle from '../../hooks/useToggle';
-import Toast from '../common/Toast/Toast';
 import shareIconSvg from '../../assets/icons/share.svg';
 import * as S from './ShareButtonStyle';
-import useToast from '../../hooks/useToast';
 import { useEffect } from 'react';
+import { useToastContext } from '../../contexts/ToastContext';
 
 const ShareButton = ({ recipientsId }) => {
+  const { showToast } = useToastContext();
   const KAKAOJSKEY = process.env.REACT_APP_KAKAOJSKEY;
-  const {
-    shouldRender,
-    isShown,
-    isSuccess,
-    showToast,
-    startHidingToast,
-    message,
-  } = useToast();
   const { isOpen, toggleRef, handleToggle, handleClose } = useToggle();
 
   const hostAddress = window.location.origin;
@@ -60,30 +52,19 @@ const ShareButton = ({ recipientsId }) => {
   }, []);
 
   return (
-    <>
-      <S.ShareButtonContainer onClick={handleToggle} ref={toggleRef}>
-        <S.ShareIcon src={shareIconSvg} alt="share icon" />
-        {isOpen && (
-          <S.ShareDropdown>
-            <S.ShareOption onClick={() => handleShareKakaoClick()}>
-              카카오톡 공유
-            </S.ShareOption>
-            <S.ShareOption onClick={() => handleShareURLClick()}>
-              URL 공유
-            </S.ShareOption>
-          </S.ShareDropdown>
-        )}
-      </S.ShareButtonContainer>
-      {shouldRender && (
-        <Toast
-          shouldRender={shouldRender}
-          isShown={isShown}
-          isSuccess={isSuccess}
-          message={message}
-          startHidingToast={startHidingToast}
-        />
+    <S.ShareButtonContainer onClick={handleToggle} ref={toggleRef}>
+      <S.ShareIcon src={shareIconSvg} alt="share icon" />
+      {isOpen && (
+        <S.ShareDropdown>
+          <S.ShareOption onClick={() => handleShareKakaoClick()}>
+            카카오톡 공유
+          </S.ShareOption>
+          <S.ShareOption onClick={() => handleShareURLClick()}>
+            URL 공유
+          </S.ShareOption>
+        </S.ShareDropdown>
       )}
-    </>
+    </S.ShareButtonContainer>
   );
 };
 

--- a/src/contexts/ToastContext.js
+++ b/src/contexts/ToastContext.js
@@ -1,6 +1,6 @@
 import React, { createContext, useContext } from 'react';
-import useToast from '../hooks/useToast';
 import Toast from '../components/common/Toast/Toast';
+import useToast from '../hooks/useToast';
 
 const ToastContext = createContext();
 

--- a/src/contexts/ToastContext.js
+++ b/src/contexts/ToastContext.js
@@ -1,0 +1,24 @@
+import React, { createContext, useContext } from 'react';
+import useToast from '../hooks/useToast';
+import Toast from '../components/common/Toast/Toast';
+
+const ToastContext = createContext();
+
+export const useToastContext = () => useContext(ToastContext);
+
+export const ToastProvider = ({ children }) => {
+  const toastProps = useToast();
+
+  return (
+    <ToastContext.Provider value={toastProps}>
+      {children}
+      <Toast
+        shouldRender={toastProps.shouldRender}
+        isShown={toastProps.isShown}
+        isSuccess={toastProps.isSuccess}
+        message={toastProps.message}
+        startHidingToast={toastProps.startHidingToast}
+      />
+    </ToastContext.Provider>
+  );
+};

--- a/src/pages/PostCreatingPage/PostCreatingPage.jsx
+++ b/src/pages/PostCreatingPage/PostCreatingPage.jsx
@@ -7,8 +7,10 @@ import getBackgroundImages from '../../apis/getBackgroundImages';
 import Button from '../../components/common/Buttons/Button/Button';
 import { postRecipient } from '../../apis/recipientRollingPaperApi';
 import { useNavigate } from 'react-router-dom';
+import { useToastContext } from '../../contexts/ToastContext';
 
 const PostCreatingPage = () => {
+  const { showToast } = useToastContext();
   const [recipient, setRecipient] = useState('');
   const [select, setSelect] = useState('color');
   const [selectedColor, setSelectedColor] = useState('beige');
@@ -65,9 +67,10 @@ const PostCreatingPage = () => {
         backgroundColor,
         backgroundImageURL,
       );
+      showToast(true, '롤링페이퍼가 생성되었습니다!');
       navigate('/post/' + response.id);
     } catch (error) {
-      alert(error.message);
+      showToast(false, error.message);
     }
   };
 

--- a/src/pages/PostWritingPage/PostWritingPage.jsx
+++ b/src/pages/PostWritingPage/PostWritingPage.jsx
@@ -9,8 +9,10 @@ import Button from '../../components/common/Buttons/Button/Button';
 import Input from '../../components/Input/Input';
 import SelectionDropdown from '../../components/SelectionDropdown/SelectionDropdown';
 import TextEditor from '../../components/TextEditor/TextEditor';
+import { useToastContext } from '../../contexts/ToastContext';
 
 const PostWritingPage = () => {
+  const { showToast } = useToastContext();
   const [senderName, setSenderName] = useState('');
   const [profileImageUrls, setProfileImageUrls] = useState([]);
   const [imageLoading, setImageLoading] = useState({});
@@ -62,9 +64,10 @@ const PostWritingPage = () => {
         content,
         font,
       );
+      showToast(true, `${sender}에 대한 롤링페이퍼를 생성하였습니다.`);
       navigate('/post/' + id);
     } catch (error) {
-      alert(error.message);
+      showToast(false, error.message);
     }
   };
 


### PR DESCRIPTION
## 🚀 작업 내용

- [x] Toast UI 에 대한 useContext 추가
- [x] 롤링페이퍼 및 대상자의 롤링페이퍼를 추가하였을때 Toast UI 를 추가

## 📝 참고 사항

- 기존 api 요청에서 롤링페이퍼와 대상자의 롤링페이퍼를 추가하였을때 Toast UI 알림을 추가하였습니다.
-

## 🖼️ 스크린샷

![Mar-11-2024 22-57-28](https://github.com/CreativePaperCrew/RollingPaper/assets/100824183/8b1da402-5e4d-48ef-a475-165e12ba38cf)
![Mar-11-2024 22-58-33](https://github.com/CreativePaperCrew/RollingPaper/assets/100824183/7d466633-faaf-4f2d-bbd2-0e37ff27738d)

![Mar-11-2024 22-58-12](https://github.com/CreativePaperCrew/RollingPaper/assets/100824183/4a6537d7-2d9a-4317-bb42-a33c3e06bd49)
![Mar-11-2024 22-58-22](https://github.com/CreativePaperCrew/RollingPaper/assets/100824183/6ba3a249-18c5-4a0e-a333-70803e7619d1)




## 🚨 관련 이슈



## ✅ 이후 계획

